### PR TITLE
move the export statement to the bottom

### DIFF
--- a/src/Scope.js
+++ b/src/Scope.js
@@ -1,8 +1,4 @@
-
-export default Scope
-
 import { getScope, getScopeAndKey, splitElements, error } from './utils'
-
 
 /**
 * The class used to manipulate the data
@@ -83,3 +79,5 @@ class Scope {
 		return this
 	}
 }
+
+export default Scope

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,6 @@
 'use strict'
 
 import parse from './parser'
-export default TOML
 
 let fs = null
 let readFile = null
@@ -36,3 +35,5 @@ TOML.parseFileSync = function(file) {
 		fs = require('fs')
 	return parse(fs.readFileSync(file))
 }
+
+export default TOML

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,9 +1,5 @@
-
-export default parse
-
 import Scope from './Scope'
 import { skipWhiteSpaces, trueValue, error, fragment, getLocation } from './utils'
-
 
 function parse(src) {
 	if (typeof src != 'string')
@@ -213,3 +209,5 @@ function parse(src) {
 
 	return scope.root
 }
+
+export default parse

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,17 +1,6 @@
 
 let fs  // we don't require the fileSystem yet because : 1. it may not be used, 2. it won't work on browsers
 
-export {
-	skipWhiteSpaces,
-	trueValue,
-	error,
-	fragment,
-	getLocation,
-	splitElements,
-	getScope,
-	getScopeAndKey,
-}
-
 /**
 * Skip whitespaces : [ \t\r]
 */
@@ -387,4 +376,15 @@ function getScopeAndKey(data, elements=[]) {
 	}
 
 	return [data, key]
+}
+
+export {
+	skipWhiteSpaces,
+	trueValue,
+	error,
+	fragment,
+	getLocation,
+	splitElements,
+	getScope,
+	getScopeAndKey,
 }


### PR DESCRIPTION
Having the export at the export will cause problems when bundling with webpack (in the context of a [sapper](https://sapper.svelte.dev/) application). The output produced by rollup will be something like this:
```js
var Scope = Scope$1;

/**
* The class used to manipulate the data
*/
class Scope$1 {
	...
}
```
Webpack will then give this error:
```
var Scope = Scope$1;
	            ^
ReferenceError: Cannot access 'Scope$1' before initialization
```